### PR TITLE
Removendo Elses obsoletos

### DIFF
--- a/query/res/result.go
+++ b/query/res/result.go
@@ -92,10 +92,9 @@ func (__obj *Result) RemoveData() []byte {
 
 		return _buff.Bytes()
 
-	} else {
-		return nil
-	}
-
+	} 
+	return nil
+	
 }
 
 //
@@ -122,8 +121,7 @@ func (__obj *Result) RemoveData2() []byte {
 
 		return _buff.Bytes()
 
-	} else {
-		return nil
-	}
+	} 
+	return nil
 
 }


### PR DESCRIPTION
Não sei como funcionam os returns no golang, mas creio que dado que dado que se o if não for executado, não há necessidade de configurar um else para dar retorno. 

So uma tentativa de ajuda mesmo amigo. Até mais. Se tiver errado o que eu fiz não tem problema.